### PR TITLE
Little changes to support new version of neovim

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -118,7 +118,9 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
     if event.match:match "^%w%w+:[\\/][\\/]" then
       return
     end
-    local file = vim.uv.fs_realpath(event.match) or event.match
+    -- support both new and old versions of neovim
+    local uv = vim.uv or vim.loop
+    local file = vim.uv.fs_realpath and uv.fs_realpath(event.match) or event.match
     vim.fn.mkdir(vim.fn.fnamemodify(file, ":p:h"), "p")
   end,
 })

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -120,7 +120,7 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
     end
     -- support both new and old versions of neovim
     local uv = vim.uv or vim.loop
-    local file = vim.uv.fs_realpath and uv.fs_realpath(event.match) or event.match
+    local file = uv.fs_realpath and uv.fs_realpath(event.match) or event.match
     vim.fn.mkdir(vim.fn.fnamemodify(file, ":p:h"), "p")
   end,
 })

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -103,10 +103,9 @@ map("n", "]q", vim.cmd.cnext, { desc = "Next Quickfix" })
 
 -- diagnostic
 local diagnostic_goto = function(next, severity)
-  local go = next and vim.diagnostic.goto_next or vim.diagnostic.goto_prev
   severity = severity and vim.diagnostic.severity[severity] or nil
-  return function()
-    go { severity = severity }
+  return function ()
+    vim.diagnostic.jump({ count = next and 1 or -1, float = true, severity = severity })
   end
 end
 map("n", "<leader>cd", vim.diagnostic.open_float, { desc = "Line Diagnostics" })


### PR DESCRIPTION
## WHAT

Replaced `vim.diagnostic.goto_next/prev` depreciation and fixed vim.uv for new old and versions of neovim.

## Types of changes

No change, just refactoring for newer versions of neovim

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Neovim configuration for compatibility with new and old versions by replacing deprecated functions and supporting different APIs.
> 
>   - **Compatibility**:
>     - Replace `vim.diagnostic.goto_next/prev` with `vim.diagnostic.jump` in `keymaps.lua` to handle diagnostics navigation.
>     - Update `vim.uv` to support both `vim.uv` and `vim.loop` in `autocmds.lua` for file path resolution.
>   - **Misc**:
>     - Minor refactoring to ensure compatibility with newer Neovim versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Ftiny-nvim&utm_source=github&utm_medium=referral)<sup> for 50fa76ed68c6697ac71ac933c586793f25d565b0. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility with different Neovim versions for automatic directory creation when saving files.
	- Enhanced diagnostic navigation for more consistent movement between diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->