### PR TITLE
docs: sync README/AGENTS with Neovim 0.13 treesitter changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,12 @@ Guide for agentic coding agents working in this Neovim configuration repository.
 
 ## Project Overview
 
-tiny-nvim is a minimal Neovim 0.11+ config that relies on built-in LSP and a curated set
-of plugins managed by lazy.nvim. Most edits are Lua under `lua/` with optional extras
-under `lua/plugins/extra/`.
+tiny-nvim is a minimal Neovim 0.11+ config (tested on 0.13) that relies on built-in LSP and a
+curated set of plugins managed by lazy.nvim. Most edits are Lua under `lua/` with optional
+extras under `lua/plugins/extra/`.
+
+Core treesitter stack: `nvim-treesitter` (`main`) + `nvim-treesitter-textobjects` (queries for
+mini.ai). Prefer `vim.uv` over `vim.loop`, and `vim.hl.hl_op` on Neovim 0.13+.
 
 ## Build, Lint, Test
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <a href="https://dotfyle.com/jellydn/tiny-nvim"><img src="https://dotfyle.com/jellydn/tiny-nvim/badges/leaderkey?style=flat" /></a>
 <a href="https://dotfyle.com/jellydn/tiny-nvim"><img src="https://dotfyle.com/jellydn/tiny-nvim/badges/plugin-manager?style=flat" /></a>
 
-> Slim Neovim config for 0.11+ with minimal plugins.
+> Slim Neovim config for 0.11+ with minimal plugins (tested on 0.13).
 
 [![Slim Neovim config for 0.11](https://i.gyazo.com/6e351d72c2f119f70dbc55d61e9452fd.png)](https://gyazo.com/6e351d72c2f119f70dbc55d61e9452fd)
 
@@ -175,7 +175,7 @@ This configuration leverages the mini.nvim plugin suite as its core UI framework
 - **mini.tabline**: Smart buffer/tabline with buffer management
 - **mini.icons**: Comprehensive icon support
 - **fff.nvim**: Fast fuzzy file picker with frecency scoring and live grep
-- **mini.ai**: Enhanced text objects for code
+- **mini.ai**: Enhanced text objects for code (treesitter-powered `af`/`if`, `ac`/`ic`, `ao`/`io` via [nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects))
 - **mini.pairs**: Automatic bracket and quote pairing
 - **mini.bufremove**: Cleaner buffer deletion
 - **mini.extra**: Additional pickers and utilities
@@ -586,10 +586,15 @@ This configuration uses [kanagawa.nvim](https://github.com/rebelot/kanagawa.nvim
 
 ### Treesitter
 
+Uses [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (`main` branch) plus [nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) for query files that power mini.ai treesitter textobjects. After pulling updates, run `:Lazy sync` so both plugins stay installed.
+
 | Key         | Description                          |
 | ----------- | ------------------------------------ |
 | `<C-space>` | Increment Selection                  |
 | `<bs>`      | Decrement Selection (in visual mode) |
+| `af` / `if` | Around / inside function (mini.ai)   |
+| `ac` / `ic` | Around / inside class (mini.ai)      |
+| `ao` / `io` | Around / inside block/loop/conditional (mini.ai) |
 
 ### Folding
 


### PR DESCRIPTION
## What

Update user-facing docs for the Neovim 0.13 / treesitter migration.

## Why

Triggered by these commits on `autoresearch/nvim-0.13-migration-2026-08-03`:

- `c16e33f` — restore mini.ai treesitter queries via `nvim-treesitter-textobjects`
- Related migration work in https://github.com/jellydn/tiny-nvim/pull/8

Users need to know about the new textobjects dependency and that `:Lazy sync` is required after pull. The `.auto/` harness and lockfile churn were skipped as non-user-facing.

## How

- README: note 0.13 testing; expand mini.ai + Treesitter sections with textobject keys
- AGENTS.md: document treesitter-textobjects and `vim.uv` / `vim.hl.hl_op` preferences

Please review for accuracy and completeness.


Made with [Cursor](https://cursor.com)